### PR TITLE
Fix Window Visibility Bug

### DIFF
--- a/KhTracker/App.config
+++ b/KhTracker/App.config
@@ -272,6 +272,18 @@
             <setting name="SavePreviousGridSetting" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="GridOptionsWindowX" serializeAs="String">
+                <value>0</value>
+            </setting>
+            <setting name="GridOptionsWindowY" serializeAs="String">
+                <value>0</value>
+            </setting>
+            <setting name="GridOptionsWindowHeight" serializeAs="String">
+                <value>1000</value>
+            </setting>
+            <setting name="GridOptionsWindowWidth" serializeAs="String">
+                <value>500</value>
+            </setting>
         </KhTracker.Properties.Settings>
     </userSettings>
   <runtime>

--- a/KhTracker/MainWindow.xaml.cs
+++ b/KhTracker/MainWindow.xaml.cs
@@ -587,6 +587,8 @@ namespace KhTracker
 
             gridWindow.canClose = true;
             gridWindow.Close();
+            gridWindow.gridOptionsWindow.canClose = true;
+            gridWindow.gridOptionsWindow.Close();
         }
 
         private void Window_LocationChanged(object sender, EventArgs e)

--- a/KhTracker/Properties/Settings.Designer.cs
+++ b/KhTracker/Properties/Settings.Designer.cs
@@ -1109,5 +1109,53 @@ namespace KhTracker.Properties {
                 this["SavePreviousGridSetting"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public double GridOptionsWindowX {
+            get {
+                return ((double)(this["GridOptionsWindowX"]));
+            }
+            set {
+                this["GridOptionsWindowX"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public double GridOptionsWindowY {
+            get {
+                return ((double)(this["GridOptionsWindowY"]));
+            }
+            set {
+                this["GridOptionsWindowY"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("1000")]
+        public double GridOptionsWindowHeight {
+            get {
+                return ((double)(this["GridOptionsWindowHeight"]));
+            }
+            set {
+                this["GridOptionsWindowHeight"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("500")]
+        public double GridOptionsWindowWidth {
+            get {
+                return ((double)(this["GridOptionsWindowWidth"]));
+            }
+            set {
+                this["GridOptionsWindowWidth"] = value;
+            }
+        }
     }
 }

--- a/KhTracker/Properties/Settings.settings
+++ b/KhTracker/Properties/Settings.settings
@@ -264,5 +264,17 @@
     <Setting Name="SavePreviousGridSetting" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="GridOptionsWindowX" Type="System.Double" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="GridOptionsWindowY" Type="System.Double" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
+    <Setting Name="GridOptionsWindowHeight" Type="System.Double" Scope="User">
+      <Value Profile="(Default)">1000</Value>
+    </Setting>
+    <Setting Name="GridOptionsWindowWidth" Type="System.Double" Scope="User">
+      <Value Profile="(Default)">500</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/KhTracker/Windows/GridOptionsWindow.xaml
+++ b/KhTracker/Windows/GridOptionsWindow.xaml
@@ -6,6 +6,9 @@
         ResizeMode="CanResize"
         Title="Grid Tracker Options" 
         WindowStartupLocation="CenterScreen"
+        LocationChanged="Window_LocationChanged"
+        SizeChanged="Window_SizeChanged"
+        Closing="Window_Closing"
         Background="LightBlue">
 
     <Window.Resources>

--- a/KhTracker/Windows/GridOptionsWindow.xaml.cs
+++ b/KhTracker/Windows/GridOptionsWindow.xaml.cs
@@ -63,7 +63,7 @@ namespace KhTracker
 
     public partial class GridOptionsWindow : Window
     {
-
+        public bool canClose = false;
         public GridWindow _gridWindow;
         public Data _data;
         int newNumRows;
@@ -297,6 +297,27 @@ namespace KhTracker
                 },
             };
             DataContext = categories;
+        }
+
+        private void Window_LocationChanged(object sender, EventArgs e)
+        {
+            Properties.Settings.Default.GridOptionsWindowY = RestoreBounds.Top;
+            Properties.Settings.Default.GridOptionsWindowX = RestoreBounds.Left;
+        }
+
+        private void Window_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            Properties.Settings.Default.GridOptionsWindowWidth = RestoreBounds.Width;
+            Properties.Settings.Default.GridOptionsWindowHeight = RestoreBounds.Height;
+        }
+
+        void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            this.Hide();
+            if (!canClose)
+            {
+                e.Cancel = true;
+            }
         }
 
         private void UpdateGridSize()

--- a/KhTracker/Windows/GridWindow.xaml
+++ b/KhTracker/Windows/GridWindow.xaml
@@ -10,7 +10,7 @@
         Height="510" Width="500"
         LocationChanged="Window_LocationChanged"
         SizeChanged="Window_SizeChanged"
-        Closing="GridWindow_Closing"
+        Closing="Window_Closing"
         MinHeight="100" MinWidth="100" Background="#303030">
 
     <Window.Resources>

--- a/KhTracker/Windows/GridWindow.xaml.cs
+++ b/KhTracker/Windows/GridWindow.xaml.cs
@@ -71,9 +71,10 @@ namespace KhTracker
             Properties.Settings.Default.GridWindowHeight = RestoreBounds.Height;
         }
 
-        void GridWindow_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        void Window_Closing(object sender, System.ComponentModel.CancelEventArgs e)
         {
             this.Hide();
+            gridOptionsWindow.Hide();
             if (!canClose)
             {
                 e.Cancel = true;
@@ -169,8 +170,9 @@ namespace KhTracker
 
         private void Grid_Options(object sender, RoutedEventArgs e)
         {
-            
-            gridOptionsWindow.ShowDialog();
+       
+            gridOptionsWindow.Show();
+
         }
 
         private List<string> Asset_Collection(string visual_type = "Min", int seed = 1)


### PR DESCRIPTION
1. Fix bug where tracker crashes upon trying to open the options grid window twice. (This was fixed by making it hidden when you press X instead of closed.) This is the same solution that the grid tracker (formally broadcast window) uses.
2. Added X, Y, Width, and Height properties for the GridOptionsWindow.